### PR TITLE
fix:修改addDeviceOrientationListener监听在UI发生横竖屏切换的时回调，而不是在设备方向发生变化时才会回调的问题

### DIFF
--- a/harmony/orientation_locker/src/main/ets/RNOrientationLockerTurboModule.ts
+++ b/harmony/orientation_locker/src/main/ets/RNOrientationLockerTurboModule.ts
@@ -9,10 +9,11 @@ import { TM } from '@rnoh/react-native-openharmony/generated/ts'
 import window from '@ohos.window'
 import display from '@ohos.display'
 import { BusinessError } from '@kit.BasicServicesKit'
+import  sensor  from '@ohos.sensor';
 
 export class RNOrientationLockerTurboModule extends TurboModule implements TM.OreitationLockerNativeModule.Spec {
   private lastDeviceOrientationValue:string = this.getOrientationString(display.getDefaultDisplaySync().orientation);
-
+  private lastDeviceSensorOrientationValue:string = "";
   constructor(ctx) {
     super(ctx)
     display.on('change', () => {
@@ -23,9 +24,29 @@ export class RNOrientationLockerTurboModule extends TurboModule implements TM.Or
       if(this.lastDeviceOrientationValue != deviceOrientationValue){
         this.lastDeviceOrientationValue = deviceOrientationValue;
         ctx.rnInstance.emitDeviceEvent('orientationDidChange', { orientation: displayValueString })
-        ctx.rnInstance.emitDeviceEvent('deviceOrientationDidChange', { deviceOrientation: displayValueString })
       }
     })
+
+    sensor.on(sensor.SensorId.ORIENTATION, (data: sensor.OrientationResponse) => {
+      console.info("orientation change z value:"+data.alpha)
+      let deviceOrientationValue:string = this.lastDeviceSensorOrientationValue;
+      let orientation=data.alpha
+      if (orientation == -1) {
+        deviceOrientationValue = "UNKNOWN";
+      } else if (orientation > 355 || orientation < 5) {
+        deviceOrientationValue = "PORTRAIT";
+      } else if (orientation > 85 && orientation < 95) {
+        deviceOrientationValue = "LANDSCAPE-RIGHT";
+      } else if (orientation > 175 && orientation < 185) {
+        deviceOrientationValue = "PORTRAIT-UPSIDEDOWN";
+      } else if (orientation > 265 && orientation < 275) {
+        deviceOrientationValue = "LANDSCAPE-LEFT";
+      }
+      if (this.lastDeviceSensorOrientationValue !== deviceOrientationValue) {
+        ctx.rnInstance.emitDeviceEvent('deviceOrientationDidChange', { deviceOrientation: deviceOrientationValue })
+        this.lastDeviceSensorOrientationValue = deviceOrientationValue;
+      }
+    }, { interval: 500000000 });
   }
 
   private windowClass: window.Window | undefined = undefined


### PR DESCRIPTION
# Summary

*   fix: 修改addDeviceOrientationListener监听在UI发生横竖屏切换的时回调的问题
    Close : [#27](https://github.com/react-native-oh-library/react-native-orientation-locker/issues/27)。

## Test Plan

![aa1d67ab7eeca388bc47b53266b0496](https://github.com/user-attachments/assets/3e87a728-1ca3-4916-8082-81280ee0fa97)


## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [X] 已经更新了文档
- [ ] 更新了 JS/TS 代码