### PR TITLE
fix:修改sensor.on监听接口的传感器上报频率

### DIFF
--- a/harmony/orientation_locker/src/main/ets/RNOrientationLockerTurboModule.ts
+++ b/harmony/orientation_locker/src/main/ets/RNOrientationLockerTurboModule.ts
@@ -46,7 +46,7 @@ export class RNOrientationLockerTurboModule extends TurboModule implements TM.Or
         ctx.rnInstance.emitDeviceEvent('deviceOrientationDidChange', { deviceOrientation: deviceOrientationValue })
         this.lastDeviceSensorOrientationValue = deviceOrientationValue;
       }
-    }, { interval: 500000000 });
+    }, { interval: 100000000 });
   }
 
   private windowClass: window.Window | undefined = undefined


### PR DESCRIPTION
# Summary

*   fix:修改sensor.on监听接口的传感器上报频率
    Close : [#30](https://github.com/react-native-oh-library/react-native-orientation-locker/issues/30)。

## Test Plan

![aa1d67ab7eeca388bc47b53266b0496](https://github.com/user-attachments/assets/3e87a728-1ca3-4916-8082-81280ee0fa97)


## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [X] 已经更新了文档
- [ ] 更新了 JS/TS 代码