### PR TITLE
fix:修改sensor.on监听接口返回的方向数据错误问题

### DIFF
--- a/harmony/orientation_locker/src/main/ets/RNOrientationLockerTurboModule.ts
+++ b/harmony/orientation_locker/src/main/ets/RNOrientationLockerTurboModule.ts
@@ -11,6 +11,8 @@ import display from '@ohos.display'
 import { BusinessError } from '@kit.BasicServicesKit'
 import  sensor  from '@ohos.sensor';
 
+const ORIENTATION_UNKNOWN = -1;
+
 export class RNOrientationLockerTurboModule extends TurboModule implements TM.OreitationLockerNativeModule.Spec {
   private lastDeviceOrientationValue:string = this.getOrientationString(display.getDefaultDisplaySync().orientation);
   private lastDeviceSensorOrientationValue:string = "";
@@ -27,11 +29,23 @@ export class RNOrientationLockerTurboModule extends TurboModule implements TM.Or
       }
     })
 
-    sensor.on(sensor.SensorId.ORIENTATION, (data: sensor.OrientationResponse) => {
-      console.info("orientation change z value:"+data.alpha)
+    sensor.on(sensor.SensorId.ACCELEROMETER, (data: sensor.AccelerometerResponse) => {
+      const X = -data.x;
+      const Y = -data.y;
+      const Z = -data.z;
+      const xyMagnitude = X * X + Y * Y;
+      const zSquared = Z * Z;
+      let orientation = ORIENTATION_UNKNOWN;
+      if (xyMagnitude * 4 >= zSquared) {
+        const angleRad = Math.atan2(-Y, X);
+        let angleDeg = 90 - (angleRad * 180 / Math.PI);
+        while (angleDeg >= 360) angleDeg -= 360;
+        while (angleDeg < 0) angleDeg += 360;
+        orientation = Math.round(angleDeg);
+      }
+
       let deviceOrientationValue:string = this.lastDeviceSensorOrientationValue;
-      let orientation=data.alpha
-      if (orientation == -1) {
+      if (orientation === ORIENTATION_UNKNOWN) {
         deviceOrientationValue = "UNKNOWN";
       } else if (orientation > 355 || orientation < 5) {
         deviceOrientationValue = "PORTRAIT";
@@ -169,5 +183,6 @@ export class RNOrientationLockerTurboModule extends TurboModule implements TM.Or
    __onDestroy__(): void {
       super.__onDestroy__()
       display.off('change')
+      sensor.off(sensor.SensorId.ACCELEROMETER)
   }
 }


### PR DESCRIPTION
# Summary

*   fix:修改sensor.on监听接口返回的方向数据错误问题
    Close : [#34](https://github.com/react-native-oh-library/react-native-orientation-locker/issues/34)。

## Test Plan

![aa1d67ab7eeca388bc47b53266b0496](https://github.com/user-attachments/assets/3e87a728-1ca3-4916-8082-81280ee0fa97)


## Checklist

- [x] 已经在真机设备测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例
- [X] 已经更新了文档
- [ ] 更新了 JS/TS 代码